### PR TITLE
Fixed Initial Error Messages in <Overview>s

### DIFF
--- a/frontend/app/components/dashboard/DriverOverview.tsx
+++ b/frontend/app/components/dashboard/DriverOverview.tsx
@@ -11,7 +11,7 @@ export default function DriverOverview() {
   const loader = useLoader(async () => {
     if (!restaurant) return null;
     const drivers = await restaurantApi.getDrivers(restaurant);
-    if (!drivers) return null;
+    if (!drivers) throw new Error('Failed to load drivers');
     return drivers.filter(driver => driver.onShift);
   }, [restaurant]);
 

--- a/frontend/app/components/dashboard/OrderOverview.tsx
+++ b/frontend/app/components/dashboard/OrderOverview.tsx
@@ -20,6 +20,7 @@ export default function OrderList() {
   const loader = useLoader(async () => {
     if (!restaurant) return null;
     const orders = await restaurantApi.getOrders(restaurant);
+    if (!orders) throw new Error('Failed to load orders');
     return orders;
   }, [restaurant]);
 

--- a/frontend/app/util/query.ts
+++ b/frontend/app/util/query.ts
@@ -6,32 +6,85 @@ export interface Loader<T> {
   reload: () => void;
 }
 
+type LoaderResult<T> =
+  | {
+      status: 'success';
+      result: T;
+    }
+  | {
+      status: 'failure';
+    }
+  | {
+      status: 'incomplete';
+    };
+
 /**
  * A hook to wrap around an asynchronous operation, which can be invoked multiple times.
  * Calling the returned object's reload method causes the loading to restart, in case of new data.
+ * The loading function can terminate in one of three ways:
+ *  1. Returning null: This indicates that the data could not meaningfully be loaded at this time
+ *  2. Throwing an error: This indicates that the data could in theory be loaded, but failed
+ *  3. Returning non-null: This indicates that the data was successfully loaded
  */
 export function useLoader<T>(
   loader: () => Promise<T>,
   dependencies: React.DependencyList = [],
 ): Loader<T> {
-  const [flag, toggleFlag] = useReducer(flag => !flag, false);
+  const [flag, reload] = useReducer(flag => !flag, false);
   const [loaded, setLoaded] = useState(true);
-  const [response, setResponse] = useState<T | null>(null);
+  const [response, setResponse] = useState<LoaderResult<T>>({
+    status: 'incomplete',
+  });
 
   useEffect(() => {
     if (!loaded) return;
 
     setLoaded(false);
 
-    void loader().then(response => {
-      setResponse(response);
-      setLoaded(true);
-    });
+    loader().then(
+      response => {
+        if (response) {
+          setResponse({
+            status: 'success',
+            result: response,
+          });
+        } else {
+          setResponse({
+            status: 'incomplete',
+          });
+        }
+        setLoaded(true);
+      },
+      () => {
+        setResponse({
+          status: 'failure',
+        });
+        setLoaded(true);
+      },
+    );
   }, [flag, ...dependencies]);
 
+  console.log(response, loaded);
+
+  if (response.status === 'success') {
+    return {
+      reload,
+      loaded: true,
+      response: response.result,
+    };
+  }
+
+  if (response.status === 'failure') {
+    return {
+      reload,
+      loaded,
+      response: null,
+    };
+  }
+
   return {
-    loaded: response ? true : loaded,
-    response,
-    reload: toggleFlag,
+    reload,
+    loaded: false,
+    response: null,
   };
 }


### PR DESCRIPTION
By making `useLoader()` more aware of different possible failure conditions, it can now treat a lack of a filled in restaurant id as a kind of continued loading state, rather than a loading error.

Closes #56 but depends on #55.