### PR TITLE
Fixed useLoader()

### DIFF
--- a/frontend/app/util/query.ts
+++ b/frontend/app/util/query.ts
@@ -37,12 +37,13 @@ export function useLoader<T>(
   });
 
   useEffect(() => {
-    if (!loaded) return;
+    let stale = false;
 
     setLoaded(false);
 
     loader().then(
       response => {
+        if (stale) return;
         if (response) {
           setResponse({
             status: 'success',
@@ -56,12 +57,17 @@ export function useLoader<T>(
         setLoaded(true);
       },
       () => {
+        if (stale) return;
         setResponse({
           status: 'failure',
         });
         setLoaded(true);
       },
     );
+
+    return () => {
+      stale = true;
+    };
   }, [flag, ...dependencies]);
 
   if (response.status === 'success') {

--- a/frontend/test/util/query.spec.ts
+++ b/frontend/test/util/query.spec.ts
@@ -71,7 +71,7 @@ describe('useLoader', () => {
     ).rejects.not.toBe(null);
   });
 
-  it('skips refetching mid-load', async () => {
+  it('refetches mid-load for consistency', async () => {
     const loadFn = makeLoadDifferent(false);
     const {result} = renderHook(() => useLoader(loadFn));
     act(() => {
@@ -80,7 +80,7 @@ describe('useLoader', () => {
     await waitFor(() => {
       const {loaded, response} = result.current;
       expect(loaded).toBe(true);
-      expect(response).toBe(1);
+      expect(response).toBe(2);
     });
   });
 


### PR DESCRIPTION
I have added a clean-up callback so that `useLoader()` can keep fetching safely even during existing loading times. This should allow for eventual consistency between the front-end and back-end.

Resolves #113.